### PR TITLE
So you know who's an admin in OOC.

### DIFF
--- a/gamemode/libs/sh_chatbox.lua
+++ b/gamemode/libs/sh_chatbox.lua
@@ -121,6 +121,10 @@ do
 	nut.chat.Register("ooc", {
 		onChat = function(speaker, text)
 			chat.AddText(Color(250, 40, 40), "[OOC] ", speaker, color_white, ": "..text)
+			
+		if (LocalPlayer():IsAdmin()) then
+			chat.AddText(Color(40, 250, 40), "[ADMIN]", speaker, color_white, ": "..text)
+			end
 		end,
 		prefix = {"//", "/ooc"},
 		deadCanTalk = true,


### PR DESCRIPTION
A nice little ADMIN tag in red as a temporary placeholder, until an icon or something to distinguish the difference between players and admins has been created.
