### PR TITLE
Notify users when they've been given money by whom.

### DIFF
--- a/gamemode/sh_commands.lua
+++ b/gamemode/sh_commands.lua
@@ -227,7 +227,7 @@ nut.command.Register({
 
 				return
 			end
-			nut.util.Notify(client:Name().." has given you "..tostring(amount).." "..nut.currency.GetName(amount)..".", entity)
+			nut.util.Notify(client:Name().." has given you "..nut.currency.GetName(amount)..".", entity)
 			entity:GiveMoney(amount)
 			client:TakeMoney(amount)
 		else


### PR DESCRIPTION
(Untested but should work)
Previously players were not given a notification when they were given money by others users, leading to confusion.
