### PR TITLE
Auto-Refresh and Attributes update

### DIFF
--- a/gamemode/core/sh_hooks.lua
+++ b/gamemode/core/sh_hooks.lua
@@ -23,9 +23,24 @@ function GM:Initialize()
 			game.ConsoleCommand("sbox_persist 1\n")
 		end
 	end
+
+	hook.Run("SetupAttributes")
 end
 
-hook.Run("SetupAttributes")
+--[[
+	Purpose: Called when an auto-refresh has occurred, a timer is used to give the game time
+	to load the schemas config files.
+--]]
+function GM:OnReloaded()
+	if (SERVER) then
+		nut.util.AddLog("NutScript has been auto-refreshed.", LOG_FILTER_MAJOR)
+	end
+	
+	timer.Simple(0.5, function()
+		hook.Run("SetupAttributes")
+		hook.Run("Refresh")
+	end)
+end
 
 --[[
 	Purpose: Allows schemas and plugins to register their attributes through a hook

--- a/gamemode/libs/sh_attributes.lua
+++ b/gamemode/libs/sh_attributes.lua
@@ -12,6 +12,12 @@ nut.attribs.buffer = {}
 	index to be used as an enum.
 --]]
 function nut.attribs.SetUp(name, desc, uniqueID, setup, limit)
+	local index = nut.attribs.Exists(uniqueID)
+
+	if (index) then
+		return index
+	end
+
 	return table.insert(nut.attribs.buffer, {name = name, desc = desc, uniqueID = uniqueID, setup = setup, limit = ( limit or nut.config.maximumPoints ) })
 end
 
@@ -23,12 +29,23 @@ function nut.attribs.GetAll()
 end
 
 --[[
-	Purpose: Takes an enum for an attribute and returns the table for the corresponding attribute.
+Purpose: Takes an enum for an attribute and returns the table for the corresponding attribute.
 --]]
 function nut.attribs.Get(index)
 	ErrorNoHalt("nut.attribs.Get() is now a deprecated function.")
-	
+
 	return nut.attribs.buffer[index]
+end
+
+--[[
+	Purpose: Takes a uniqueID for an attribute and returns the table index for the corresponding attribute.
+--]]
+function nut.attribs.Exists(id)
+	for k,v in pairs(nut.attribs.buffer) do
+		if (v.uniqueID == id) then
+			return k
+		end
+	end
 end
 
 if (SERVER) then


### PR DESCRIPTION
Added new hook Refresh that occurs when an auto-refresh has happened. Fixed SetupAttributes being broken by last commit, updated attributes library to avoid duplicating attributes after a refresh by checking if it already exists or not via its uniqueID.
