### PR TITLE
Fix: SortedPairs seems to copy the members it iterates over. In this cas...

### DIFF
--- a/gamemode/derma/cl_business.lua
+++ b/gamemode/derma/cl_business.lua
@@ -28,7 +28,7 @@ local PANEL = {}
 				table.insert(categories[v.category], v)
 			end
 
-			for _, items in SortedPairs(categories) do
+			for _, items in nut.util.SortedPairs(categories) do
 				for _, itemTable in SortedPairsByMemberValue(items, "name") do
 					local class = itemTable.uniqueID
 					local allowed = true

--- a/gamemode/derma/cl_classes.lua
+++ b/gamemode/derma/cl_classes.lua
@@ -9,7 +9,7 @@ local PANEL = {}
 		self.list:Dock(FILL)
 		self.list:SetDrawBackground(true)
 
-		for k, v in SortedPairs(nut.class.GetByFaction(LocalPlayer():Team())) do
+		for k, v in nut.util.SortedPairs(nut.class.GetByFaction(LocalPlayer():Team())) do
 			if (LocalPlayer():CharClass() != k and v:PlayerCanJoin(LocalPlayer())) then
 				local item = self.list:Add("nut_ClassItem")
 				item:DockMargin(3, 3, 3, 0)

--- a/gamemode/derma/cl_help.lua
+++ b/gamemode/derma/cl_help.lua
@@ -42,7 +42,7 @@ local PANEL = {}
 			self:SetHTML(prefix..html)
 		end
 
-		for k, v in SortedPairs(help) do
+		for k, v in nut.util.SortedPairs(help) do
 			local node = self.tree:AddNode(k)
 			node.Icon:SetImage(v[2])
 			node.DoClick = function()

--- a/gamemode/derma/cl_inventory.lua
+++ b/gamemode/derma/cl_inventory.lua
@@ -54,75 +54,75 @@ local PANEL = {}
 			table.insert(categories[itemTable.category], {k, v, itemTable.name})
 		end
 
-		for _, items2 in SortedPairs(categories) do
+		for _, items2 in nut.util.SortedPairs(categories) do
 			for _, data in SortedPairsByMemberValue(items2, 3) do
 				local class = data[1]
 				local items = data[2]
-				local itemTable = nut.item.Get(class)
+			local itemTable = nut.item.Get(class)
 
-				if (itemTable and table.Count(items) > 0) then
-					local category = itemTable.category
-					local category2 = string.lower(category)
+			if (itemTable and table.Count(items) > 0) then
+				local category = itemTable.category
+				local category2 = string.lower(category)
 
-					if (!self.categories[category2]) then
-						local category3 = self.list:Add("DCollapsibleCategory")
-						category3:Dock(TOP)
-						category3:SetLabel(category)
-						category3:DockMargin(5, 5, 5, 5)
-						category3:SetPadding(5)
+				if (!self.categories[category2]) then
+					local category3 = self.list:Add("DCollapsibleCategory")
+					category3:Dock(TOP)
+					category3:SetLabel(category)
+					category3:DockMargin(5, 5, 5, 5)
+					category3:SetPadding(5)
 
-						local list = vgui.Create("DIconLayout")
-							list.Paint = function(list, w, h)
-								surface.SetDrawColor(0, 0, 0, 25)
-								surface.DrawRect(0, 0, w, h)
-							end
-						category3:SetContents(list)
-						category3:InvalidateLayout(true)
-
-						self.categories[category2] = {list = list, category = category3, panel = panel}
-					end
-
-					local list = self.categories[category2].list
-
-					for k, v in SortedPairs(items) do
-						local icon = list:Add("SpawnIcon")
-						icon:SetModel(itemTable.model or "models/error.mdl", itemTable.skin)
-
-						if (itemTable.bodygroup) then
-							for k, v in pairs(itemTable.bodygroup) do
-								icon:SetBodyGroup( k, v )
-							end
+					local list = vgui.Create("DIconLayout")
+						list.Paint = function(list, w, h)
+							surface.SetDrawColor(0, 0, 0, 25)
+							surface.DrawRect(0, 0, w, h)
 						end
+					category3:SetContents(list)
+					category3:InvalidateLayout(true)
 
-						icon.PaintOver = function(icon, w, h)
-							surface.SetDrawColor(0, 0, 0, 45)
-							surface.DrawOutlinedRect(1, 1, w - 2, h - 2)
-
-							if (itemTable.PaintIcon) then
-								itemTable.data = v.data
-									itemTable:PaintIcon(w, h)
-								itemTable.data = nil
-							end
-						end
-						
-						local label = icon:Add("DLabel")
-						label:SetPos(8, 3)
-						label:SetWide(64)
-						label:SetText(v.quantity)
-						label:SetFont("DermaDefaultBold")
-						label:SetDark(true)
-						label:SetExpensiveShadow(1, Color(240, 240, 240))
-
-						icon:SetToolTip(nut.lang.Get("item_info", itemTable.name, itemTable:GetDesc(v.data)))
-						icon.DoClick = function(icon)
-							nut.item.OpenMenu(itemTable, v, k, icon, label)
-						end
-					end
-				elseif (table.Count(items) == 0) then
-					LocalPlayer():GetInventory()[class] = nil
+					self.categories[category2] = {list = list, category = category3, panel = panel}
 				end
+
+				local list = self.categories[category2].list
+
+				for k, v in nut.util.SortedPairs(items) do
+					local icon = list:Add("SpawnIcon")
+					icon:SetModel(itemTable.model or "models/error.mdl", itemTable.skin)
+
+					if (itemTable.bodygroup) then
+						for k, v in pairs(itemTable.bodygroup) do
+							icon:SetBodyGroup( k, v )
+						end
+					end
+
+					icon.PaintOver = function(icon, w, h)
+						surface.SetDrawColor(0, 0, 0, 45)
+						surface.DrawOutlinedRect(1, 1, w - 2, h - 2)
+
+						if (itemTable.PaintIcon) then
+							itemTable.data = v.data
+								itemTable:PaintIcon(w, h)
+							itemTable.data = nil
+						end
+					end
+					
+					local label = icon:Add("DLabel")
+					label:SetPos(8, 3)
+					label:SetWide(64)
+					label:SetText(v.quantity)
+					label:SetFont("DermaDefaultBold")
+					label:SetDark(true)
+					label:SetExpensiveShadow(1, Color(240, 240, 240))
+
+					icon:SetToolTip(nut.lang.Get("item_info", itemTable.name, itemTable:GetDesc(v.data)))
+					icon.DoClick = function(icon)
+						nut.item.OpenMenu(itemTable, v, k, icon, label)
+					end
+				end
+			elseif (table.Count(items) == 0) then
+				LocalPlayer():GetInventory()[class] = nil
 			end
 		end
+	end
 	end
 
 	nut.char.HookVar("inv", "refreshInv", function(character)

--- a/gamemode/derma/cl_menu.lua
+++ b/gamemode/derma/cl_menu.lua
@@ -86,7 +86,7 @@ local PANEL = {}
 
 		local count = 0
 
-		for k, v in SortedPairs(nut.class.GetByFaction(LocalPlayer():Team())) do
+		for k, v in nut.util.SortedPairs(nut.class.GetByFaction(LocalPlayer():Team())) do
 			if (LocalPlayer():CharClass() != k and v:PlayerCanJoin(LocalPlayer())) then
 				count = count + 1
 			end

--- a/gamemode/libs/sh_character.lua
+++ b/gamemode/libs/sh_character.lua
@@ -496,7 +496,7 @@ if (SERVER) then
 		
 		nut.db.FetchTable("steamid = "..(client:SteamID64() or 0)..sameSchema(), "id", function(_, data)
 			if (IsValid(client)) then
-				for k, v in SortedPairs(data) do
+				for k, v in nut.util.SortedPairs(data) do
 					nut.char.SendInfo(client, v.id)
 				end
 

--- a/gamemode/libs/sh_commands.lua
+++ b/gamemode/libs/sh_commands.lua
@@ -172,7 +172,7 @@ else
 		data:AddHelp("Commands", function(tree)
 			local html = ""
 
-			for k, v in SortedPairs(nut.command.buffer) do
+			for k, v in nut.util.SortedPairs(nut.command.buffer) do
 				if (!v.category) then
 					if (v.adminOnly and !LocalPlayer():IsAdmin()) then
 						continue
@@ -197,7 +197,7 @@ else
 		end, "icon16/comments.png")
 
 		data:AddCallback("Commands", function(node, body)
-			for k, v in SortedPairs(nut.command.buffer) do
+			for k, v in nut.util.SortedPairs(nut.command.buffer) do
 				if (v.category) then
 					if (v.adminOnly and !LocalPlayer():IsAdmin()) then
 						continue

--- a/gamemode/libs/sh_flag.lua
+++ b/gamemode/libs/sh_flag.lua
@@ -35,7 +35,7 @@ else
 		data:AddHelp("Flags", function()
 			local html = ""
 
-			for k, v in SortedPairs(nut.flag.buffer) do
+			for k, v in nut.util.SortedPairs(nut.flag.buffer) do
 				local color = "<font color=\"red\">&#10008;"
 
 				if (LocalPlayer():HasFlag(k)) then

--- a/gamemode/libs/sh_item.lua
+++ b/gamemode/libs/sh_item.lua
@@ -763,7 +763,7 @@ do
 			end
 
 			local menu = DermaMenu()
-				for k, v in SortedPairs(itemTable.functions) do
+				for k, v in nut.util.SortedPairs(itemTable.functions) do
 					if (v.shouldDisplay and v.shouldDisplay(itemTable, item.data) == false) then
 						continue
 					end
@@ -803,7 +803,7 @@ do
 			end
 
 			local menu = DermaMenu()
-				for k, v in SortedPairs(itemTable.functions) do
+				for k, v in nut.util.SortedPairs(itemTable.functions) do
 					if (v.shouldDisplay and v.shouldDisplay(itemTable, entity:GetData(), entity) == false) then
 						continue
 					end

--- a/gamemode/libs/sh_plugin.lua
+++ b/gamemode/libs/sh_plugin.lua
@@ -204,7 +204,7 @@ if (CLIENT) then
 		data:AddHelp("Plugins", function()
 			local html = ""
 
-			for k, v in SortedPairs(nut.plugin.buffer) do
+			for k, v in nut.util.SortedPairs(nut.plugin.buffer) do
 				html = html.."<p><b>"..(v.name or k).."</b><br /><i>Author:</i> "..(v.author or "Anonymous").."<br /><i>Description:</i> "..v.desc or nut.lang.Get("no_desc").."</p>"
 			end
 

--- a/gamemode/sh_util.lua
+++ b/gamemode/sh_util.lua
@@ -39,6 +39,63 @@ function nut.util.Include(fileName, state)
 end
 
 --[[
+	Copied from https://github.com/garrynewman/garrysmod
+]]--
+local function fnPairsSorted( pTable, Index )
+
+if ( Index == nil ) then
+
+Index = 1
+
+else
+
+for k, v in pairs( pTable.__SortedIndex ) do
+if ( v == Index ) then
+Index = k + 1
+break
+end
+end
+
+end
+
+local Key = pTable.__SortedIndex[ Index ]
+if ( !Key ) then
+pTable.__SortedIndex = nil
+return
+end
+
+Index = Index + 1
+
+return Key, pTable[ Key ]
+
+end
+
+--[[
+	Purpose: Iterates over a table sorted by key. Doesn't recursively copy tables,
+	unlike the default SortedPairs.
+--]]
+function nut.util.SortedPairs(originalTable, Desc)
+	copiedTable = {}
+	for k, v  in pairs(originalTable) do
+		copiedTable[k] = v
+	end
+
+	local SortedIndex = {}
+	for k, v in pairs( copiedTable ) do
+		table.insert( SortedIndex, k )
+	end
+
+	if ( Desc ) then
+		table.sort( SortedIndex, function(a,b) return a>b end )
+	else
+		table.sort( SortedIndex )
+	end
+	copiedTable.__SortedIndex = SortedIndex
+
+	return fnPairsSorted, copiedTable, nil
+end
+
+--[[
 	Purpose: Gets the appropriate alpha value for colors using two vectors.
 --]]
 function nut.util.GetAlphaFromDist(position, goal, maxDistance, maxAlpha)


### PR DESCRIPTION
Fix: SortedPairs seems to copy the members it iterates over. In this case, copying item.data, meaning that it item.data can't be edited inside item.functions.X on the Client only.

Implemented a custom version of SortedPairs (nut.util.SortedPairs) that solves this issue, but is otherwise identical.

Workarounds involve accessing the item directly through self.GetInventory() and equivalent.
