### PR TITLE
A typo in the chatbox (whipser == whisper)

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -192,7 +192,7 @@ do
 
 		-- Whisper chat.
 		nut.chat.register("w", {
-			format = "%s whipsers \"%s\"",
+			format = "%s whispers \"%s\"",
 			onGetColor = function(speaker, text)
 				local color = nut.chat.classes.ic.onGetColor(speaker, text)
 


### PR DESCRIPTION
The grammar nazi inside me wanted me to change this.
