### PR TITLE
Fixed PM being visible to everyone

### DIFF
--- a/gamemode/libs/sh_chatbox.lua
+++ b/gamemode/libs/sh_chatbox.lua
@@ -231,6 +231,10 @@ if (CLIENT) then
 
 	hook.Add("ChatTextChanged", "nut_Typing", function(text)
 		if (nut.config.showTypingText) then
+			if (string.sub(text, 1, 3) == "/pm") then
+				text = "PM..."
+			end
+
 			if (nextSend < CurTime()) then
 				netstream.Start("nut_Typing", text)
 				nextSend = CurTime() + 0.25


### PR DESCRIPTION
PM will no longer be displayed on the overhead chat.
If a player's message starts by "/pm" his overhead chat will display "PM...".