### PR TITLE
getModelClass fix

### DIFF
--- a/gamemode/core/libs/sh_anims.lua
+++ b/gamemode/core/libs/sh_anims.lua
@@ -302,12 +302,19 @@ end
 
 function nut.anim.getModelClass(model)
 	model = model:lower()
-
-	if (model:find("/player")) then
+	local translatedClass = translations[model]
+	
+	if (model:find("/player") and not translatedClass) then
 		return "player"
 	end
 
-	return translations[model:lower()] or "citizen_male"
+	local class = translatedClass or "citizen_male"
+
+	if (class == "citizen_male" and (model:find("female" or model:find("alyx") or model:find("mossman")))) then
+		class = "citizen_female"
+	end
+	
+	return class
 end
 
 nut.anim.setModelClass("models/police.mdl", "metrocop")


### PR DESCRIPTION
Fixed getModelClass to allow models with "player" in the path to have custom anims, as before they were overridden regardless.
