### PR TITLE
Data can now be sent with item actions

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -579,7 +579,7 @@ do
 			end
 		end)
 
-		netstream.Hook("invAct", function(client, action, item, invID)
+		netstream.Hook("invAct", function(client, action, item, invID, clientData)
 			local character = client:getChar()
 
 			if (!character) then
@@ -627,18 +627,28 @@ do
 
 			if (item.entity) then
 				if (item.entity:GetPos():Distance(client:GetPos()) > 96) then
+					item.entity = nil
+					item.player = nil
+
 					return
 				end
 			elseif (!inventory:getItemByID(item.id)) then
+				item.player = nil
+	
 				return
 			end
 
 			local callback = item.functions[action]
 
 			if (callback) then
+				if (istable(clientData)) then
+					item.clientData = clientData
+				end
+
 				if (callback.onCanRun and callback.onCanRun(item) == false) then
 					item.entity = nil
 					item.player = nil
+					item.clientData = nil
 
 					return
 				end
@@ -660,6 +670,7 @@ do
 
 				item.entity = nil
 				item.player = nil
+				item.clientData = nil
 			end
 		end)
 	end


### PR DESCRIPTION
This small change allows the client to send any kind of data along with
an "action" request on an item.

This can extend and simplify interactivity functionality for items. A
usage example:
A notepad item which you can write on. Instead of using additional
netstreams to network text to the server, the write function now opens a
VGUI panel on the client, and when the player decides to save their
changes, the panel starts an "invAct" netstream with this additional
data attached to it. Serverside, the item can now decide what to do with
this data.

With a few utility functions, this can be made as simple as calling
something like item:callOnServer(...) in a VGUI panel.
