### PR TITLE
Add posthooking for items

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -133,6 +133,7 @@ function nut.item.register(uniqueID, baseID, isBaseItem, path, luaGenerated)
 			ITEM.base = baseID
 			ITEM.isBase = isBaseItem
 			ITEM.hooks = ITEM.hooks or {}
+			ITEM.postHooks = ITEM.postHooks or {}
 			ITEM.functions = ITEM.functions or {}
 			ITEM.functions.drop = ITEM.functions.drop or {
 				tip = "dropTip",
@@ -652,6 +653,11 @@ do
 				
 				if (result == nil) then
 					result = callback.onRun(item)
+				end
+
+				if (item.postHooks[action]) then
+					-- Posthooks shouldn't override the result from onRun
+					item.postHooks[action](item)
 				end
 				
 				if (result != false) then

--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -150,6 +150,12 @@ function ITEM:hook(name, func)
 	end
 end
 
+function ITEM:postHook(name, func)
+	if (name) then
+		self.postHooks[name] = func
+	end
+end
+
 function ITEM:remove()
 	local inv = nut.item.inventories[self.invID]
 	local x2, y2


### PR DESCRIPTION
Found myself needing this for weapon items. Since onRun is what gives the player the weapon, you cannot access the weapon entity in the regular (pre)hook.
