### PR TITLE
Save steamName in nut_players instead of name

### DIFF
--- a/gamemode/core/libs/sv_player.lua
+++ b/gamemode/core/libs/sv_player.lua
@@ -3,7 +3,7 @@ local playerMeta = FindMetaTable("Player")
 -- Player data (outside of characters) handling.
 do
 	function playerMeta:loadNutData(callback)
-		local name = self:Name()
+		local name = self:SteamName()
 		local steamID64 = self:SteamID64()
 		local timeStamp = math.floor(os.time())
 		local ip = self:IPAddress():match("%d+%.%d+%.%d+%.%d+")

--- a/gamemode/core/libs/sv_player.lua
+++ b/gamemode/core/libs/sv_player.lua
@@ -3,7 +3,7 @@ local playerMeta = FindMetaTable("Player")
 -- Player data (outside of characters) handling.
 do
 	function playerMeta:loadNutData(callback)
-		local name = self:SteamName()
+		local name = self:steamName()
 		local steamID64 = self:SteamID64()
 		local timeStamp = math.floor(os.time())
 		local ip = self:IPAddress():match("%d+%.%d+%.%d+%.%d+")


### PR DESCRIPTION
The nut_players table has a column to show "SteamName", this column shows the character name instead because it was self:Name() instead of self:SteamName()
