### PR TITLE
Display bodygroups and skins on character load

### DIFF
--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -393,8 +393,10 @@ local PANEL = {}
 								self.model.teamColor = team.GetColor(character:getFaction())
 								
 								self.model.Entity:SetSkin(character.vars.data.skin or 0)
-								for k, v in pairs(character.vars.data.groups) do
-									self.model.Entity:SetBodygroup(k, character.vars.data.groups[k])
+								if(character.vars.data.groups) then
+									for k, v in pairs(character.vars.data.groups) do
+										self.model.Entity:SetBodygroup(k, character.vars.data.groups[k])
+									end
 								end
 								
 								id = character:getID()

--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -391,7 +391,12 @@ local PANEL = {}
 							if (id != character:getID()) then
 								self.model:SetModel(character:getModel())
 								self.model.teamColor = team.GetColor(character:getFaction())
-
+								
+								self.model.Entity:SetSkin(character.vars.data.skin or 0)
+								for k, v in pairs(character.vars.data.groups) do
+									self.model.Entity:SetBodygroup(k, character.vars.data.groups[k])
+								end
+								
 								id = character:getID()
 							end
 						end


### PR DESCRIPTION
Added code to display character bodygroups and skins (if any) on character load.
I won't say it's not networked or requires a lot of networking as mentioned in #578
