### PR TITLE
Fixes inventory being stuck to the left

### DIFF
--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -400,6 +400,7 @@ hook.Add("CreateMenuButtons", "nutInventory", function(tabs)
 
 			if (inventory) then
 				nut.gui.inv1:setInventory(inventory)
+				nut.gui.inv1:SetPos(ScrW()/3, ScrH()/3)
 			end
 		end
 	end


### PR DESCRIPTION
Seems a Gmod update broke the inventory so I made this easy fix to keep it centered, fixes #653 
