### PR TITLE
Update cl_scoreboard.lua

### DIFF
--- a/gamemode/core/derma/cl_scoreboard.lua
+++ b/gamemode/core/derma/cl_scoreboard.lua
@@ -18,7 +18,7 @@ local PANEL = {}
 		self:Center()
 
 		self.title = self:Add("DLabel")
-		self.title:SetText(GetConVarString("hostname"))
+		self.title:SetText(GetHostName())
 		self.title:SetFont("nutBigFont")
 		self.title:SetContentAlignment(5)
 		self.title:SetTextColor(color_white)


### PR DESCRIPTION
Fixed bug, when name of server displayed incorrectly as "Garry's Mod"
